### PR TITLE
fix(version): set default version to 'dev'

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import "github.com/dmlittle/scenery/pkg/cmd"
 
 // Version is updated by linker flags during build time
-var Version = ""
+var Version = "dev"
 
 func main() {
 	cmd.Execute(Version)


### PR DESCRIPTION
## What
Set default `Version` to `"dev"`. 

## Why
When using `go get` to install scenery it will build the executable locally without setting the `Version` value through a flag. 