### PR TITLE
fix(parser): recover from parser panics and return original input

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -74,15 +74,6 @@ type Attribute struct {
 	_             *string `parser:"\"\\n\""`
 }
 
-// DEBUG HELPER
-// func() participle.Option {
-// 	fmt.Printf("%#v\n", lexer.SymbolsByRune(lexer.TextScannerLexer))
-// 	return participle.Map(func(token lexer.Token) (lexer.Token, error) {
-// 		fmt.Printf("%#v\n", token)
-// 		return token, nil
-// 	})
-// }(),
-
 const noChanges = "NO_CHANGES_STRING"
 
 // ErrParseFailure is returned by parser.Parse when the input string is unable
@@ -95,6 +86,13 @@ var ErrParseFailure = errors.New("validator not registered")
 // The ParseFailureErr error is returned the string is not able to be parsed
 // properly by the grammar.
 func Parse(inputPlan string) (*Plan, error) {
+	defer func() {
+		// Parse will panic in the event of unrecognized character sequences or
+		// unsupported tokens. If we cannot parse the input it means it's not a
+		// valid terraform plan. We'll recover and return the original input.
+		recover()
+	}()
+
 	p, err := participle.Build(&Plan{}, participle.Lexer(&SceneryDefinition{}))
 	if err != nil {
 		return &Plan{}, err


### PR DESCRIPTION
A wrongful input can cause a panic during the parsing set of the input (unrecognized characters or illegal character sequences). If a panic does occur, let's recover and display the original input without doing any further processing (since it's not a terraform plan).