### PR TITLE
fix(diff): json.Marshal JSON diff to ensure formatting is equal

### DIFF
--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -115,10 +115,18 @@ func processComplexAttributes(a *parser.Attribute, indentLength int) {
 		isBeforeJSON := json.Valid(bBefore) && (*a.Before)[0] == '{'
 		isAfterJSON := json.Valid(bAfter) && (*a.After)[0] == '{'
 
+		var old, new map[string]interface{}
+
+		json.Unmarshal(bBefore, &old) // nolint:gosec
+		json.Unmarshal(bAfter, &new)  // nolint:gosec
+
+		oldPretty, _ := json.MarshalIndent(old, "", "  ") // nolint:gosec
+		newPretty, _ := json.MarshalIndent(new, "", "  ") // nolint:gosec
+
 		if isBeforeJSON && isAfterJSON {
 			diff := difflib.UnifiedDiff{
-				A:       difflib.SplitLines(*a.Before),
-				B:       difflib.SplitLines(*a.After),
+				A:       difflib.SplitLines(string(oldPretty)),
+				B:       difflib.SplitLines(string(newPretty)),
 				Context: 5,
 				Eol:     "\n",
 			}


### PR DESCRIPTION
## What
Prettify both `before` and `after` attribute values before comparing them and creating a diff.

## Why
In some cases, the JSON values have different formatting (padding, new lines, etc.) that cause the text representation to be different but the JSON value to be semantically the same. We can normalize the JSON string by unmarshalling and re-marshalling the values.