### PR TITLE
fix(parser): allow slash symbols in attribute keys

### DIFF
--- a/fixtures/processedPlans/complex.txt
+++ b/fixtures/processedPlans/complex.txt
@@ -15,4 +15,5 @@
       attribute: "" => <computed>
 
   -/+ aws_instance.example (new resource required)
-    ami: "ami-2757f631" => "ami-b374d5a5" (forces new resource)
+    ami:                              "ami-2757f631" => "ami-b374d5a5" (forces new resource)
+    instance_tags.k8s.io/role/master: "1"

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -64,7 +64,7 @@ type Header struct {
 //   `policy_arn:      "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"``
 //   `allow_overwrite: "" => "true"`
 type Attribute struct {
-	Key           *string `parser:"@(Ident { \".\" | \"#\" | \"%\" | \"~\"| Ident | Float }) \":\""`
+	Key           *string `parser:"@(Ident { \".\" | \"#\" | \"%\" | \"~\" | \"/\" | Ident | Float }) \":\""`
 	Before        *string `parser:"((@String \"=\" \">\""`
 	After         *string `parser:"  (@String"`
 	AfterComputed *string `parser:" 	| @(\"<\" Ident \">\")))"`

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -204,6 +204,10 @@ func TestParse(t *testing.T) {
 							After:       String("ami-b374d5a5"),
 							NewResource: true,
 						},
+						{
+							Key:   String("instance_tags.k8s.io/role/master"),
+							Value: String("1"),
+						},
 					},
 				},
 			}}


### PR DESCRIPTION
According to [docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions) `/` is allowed in tag names. Its commonly used in k8s resource tags (example added in tests). Before this change I was getting similar errors during parsing:

```
<source>:130:27: unexpected "/" (expected ":")
Failed to parse plan. Returning original input.
validator not registered
```