### PR TITLE
fix(parser): allow hyphen in attribute keys

### DIFF
--- a/fixtures/processedPlans/complex.txt
+++ b/fixtures/processedPlans/complex.txt
@@ -17,3 +17,4 @@
   -/+ aws_instance.example (new resource required)
     ami:                              "ami-2757f631" => "ami-b374d5a5" (forces new resource)
     instance_tags.k8s.io/role/master: "1"
+    k8s.io/cluster-autoscaler:        "nodes"

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -64,7 +64,7 @@ type Header struct {
 //   `policy_arn:      "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"``
 //   `allow_overwrite: "" => "true"`
 type Attribute struct {
-	Key           *string `parser:"@(Ident { \".\" | \"#\" | \"%\" | \"~\" | \"/\" | Ident | Float }) \":\""`
+	Key           *string `parser:"@(Ident { \".\" | \"#\" | \"%\" | \"~\" | \"/\" | \"-\" | Ident | Float }) \":\""`
 	Before        *string `parser:"((@String \"=\" \">\""`
 	After         *string `parser:"  (@String"`
 	AfterComputed *string `parser:" 	| @(\"<\" Ident \">\")))"`

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -208,6 +208,10 @@ func TestParse(t *testing.T) {
 							Key:   String("instance_tags.k8s.io/role/master"),
 							Value: String("1"),
 						},
+						{
+							Key:   String("k8s.io/cluster-autoscaler"),
+							Value: String("nodes"),
+						},
 					},
 				},
 			}}


### PR DESCRIPTION
Same as #14  but for `-`