### PR TITLE
feat(diff): add diff for base64 values

### DIFF
--- a/fixtures/rawPlans/base64Input.txt
+++ b/fixtures/rawPlans/base64Input.txt
@@ -1,0 +1,3 @@
+  ~ aws_instance.example
+    userd_data_hash:  "e32a558d4e72c9157173e8b0f9e64f4ec59b6e857b79b2a5e71084fe6f4f1dbd" => "c37647d0ba0c466d9f36039dea07426394f74d76a739f55e904d3e5c31abdfc4"
+    user_data_base64: "IyEgL2Jpbi9iYXNoCgplY2hvICJmb28iCg==" => "IyEgL2Jpbi9iYXNoCgplY2hvICJiYXIiCg=="

--- a/fixtures/rawPlans/base64Output.txt
+++ b/fixtures/rawPlans/base64Output.txt
@@ -1,0 +1,9 @@
+~ aws_instance.example
+    userd_data_hash:  "e32a558d4e72c9157173e8b0f9e64f4ec59b6e857b79b2a5e71084fe6f4f1dbd" => "c37647d0ba0c466d9f36039dea07426394f74d76a739f55e904d3e5c31abdfc4" 
+    user_data_base64:  #! /bin/bash
+                       
+                      -echo "foo"
+                      +echo "bar"
+                       
+                      
+

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -1,10 +1,12 @@
 package printer
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode"
 
 	"github.com/dmlittle/scenery/pkg/parser"
 	"github.com/fatih/color"
@@ -119,6 +121,18 @@ func processComplexAttributes(a *parser.Attribute, indentLength int) {
 		isBeforeJSON := json.Valid(bBefore) && ((*a.Before)[0] == '{' || (*a.Before)[0] == '[')
 		isAfterJSON := json.Valid(bAfter) && ((*a.After)[0] == '{' || (*a.After)[0] == '[')
 
+		isBeforeBase64 := false
+		oldString, err := base64.StdEncoding.DecodeString(string(bBefore))
+		if err == nil {
+			isBeforeBase64 = true
+		}
+
+		isAfterBase64 := false
+		newString, err := base64.StdEncoding.DecodeString(string(bAfter))
+		if err == nil {
+			isAfterBase64 = true
+		}
+
 		var old, new interface{}
 
 		json.Unmarshal(bBefore, &old) // nolint:gosec
@@ -131,6 +145,15 @@ func processComplexAttributes(a *parser.Attribute, indentLength int) {
 			diff := difflib.UnifiedDiff{
 				A:       difflib.SplitLines(string(oldPretty)),
 				B:       difflib.SplitLines(string(newPretty)),
+				Context: 5,
+			}
+			diffText, _ := difflib.GetUnifiedDiffString(diff) // nolint: gosec
+
+			printDiffAttribute(*a.Key, diffText, indentLength)
+		} else if isBeforeBase64 && isAfterBase64 && isASCII(oldString) && isASCII(newString) {
+			diff := difflib.UnifiedDiff{
+				A:       difflib.SplitLines(string(oldString)),
+				B:       difflib.SplitLines(string(newString)),
 				Context: 5,
 			}
 			diffText, _ := difflib.GetUnifiedDiffString(diff) // nolint: gosec
@@ -277,6 +300,16 @@ func printMetadata(metadata *parser.Metadata) {
 func isTerraformReference(s *string) bool {
 	terraformReference := regexp.MustCompile(`\$\{[a-zA-Z-_\.]+\}`)
 	return terraformReference.MatchString(*s)
+}
+
+func isASCII(b []byte) bool {
+	s := string(b)
+	for i := 0; i < len(s); i++ {
+		if s[i] > unicode.MaxASCII {
+			return false
+		}
+	}
+	return true
 }
 
 func getTypeColor(c *string) *color.Color {

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -1,0 +1,72 @@
+package printer
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/dmlittle/scenery/pkg/parser"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintPlan(t *testing.T) {
+	cases := []struct {
+		inputFile  string
+		outputFile string
+	}{
+		{"../../fixtures/rawPlans/base64Input.txt", "../../fixtures/rawPlans/base64Output.txt"},
+	}
+
+	for _, tc := range cases {
+		input, err := ioutil.ReadFile(tc.inputFile)
+		assert.NoError(t, err)
+
+		expected, err := ioutil.ReadFile(tc.outputFile)
+		assert.NoError(t, err)
+
+		plan, err := parser.Parse(string(input))
+		assert.NoError(t, err)
+
+		output := captureOutput(func() {
+			PrettyPrint(plan)
+		})
+
+		assert.Equal(t, string(expected), output)
+	}
+}
+
+// https://gist.github.com/hauxe/e935a7f9012bf2649710cf75af323dbf#file-output_capturing_full-go
+func captureOutput(f func()) string {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	stdout := os.Stdout
+	stderr := os.Stderr
+	defer func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+		log.SetOutput(os.Stderr)
+	}()
+	os.Stdout = writer
+	os.Stderr = writer
+	log.SetOutput(writer)
+	out := make(chan string)
+	wg := new(sync.WaitGroup)
+	wg.Add(1)
+	go func() {
+		var buf bytes.Buffer
+		wg.Done()
+		io.Copy(&buf, reader)
+		out <- buf.String()
+	}()
+	wg.Wait()
+	f()
+	writer.Close()
+	return <-out
+}


### PR DESCRIPTION
This will try to check if values is base64 encoded and print pretty diff for it instead of a wall of symbols.
Before:
<img width="678" alt="screenshot 2019-02-19 at 16 54 56" src="https://user-images.githubusercontent.com/9439689/53123028-c9c87180-3560-11e9-9e06-b7d895c8584a.png">

After:
<img width="676" alt="screenshot 2019-02-19 at 16 55 13" src="https://user-images.githubusercontent.com/9439689/53123044-d4830680-3560-11e9-9506-fe28174c6f08.png">

