### PR TITLE
Fix printer issue related to templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .vscode/
 tsconfig.json
 jsconfig.json
+.idea
 
 ### Go ###
 # Binaries for programs and plugins

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ GOTOOLS := \
 	github.com/git-chglog/git-chglog/cmd/git-chglog \
 	github.com/golang/dep/cmd/dep \
 	golang.org/x/tools/cmd/cover \
+	github.com/stretchr/testify/assert \
 
 DIRS     ?= $(shell find . -name '*.go' | grep --invert-match 'vendor' | xargs -n 1 dirname | sort --unique)
 PKG_NAME ?= scenery

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -240,9 +240,7 @@ func formatValue(value string, indentLength int) string {
 
 		formattedValue := strings.Replace(value, "\n", newlineReplacement, -1)
 
-		lastNewlineIndex := strings.LastIndex(formattedValue, "\n")
-
-		return formattedValue[:lastNewlineIndex]
+		return formattedValue
 	}
 
 	return value

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -80,13 +80,9 @@ func TestPrint(t *testing.T) {
 			"           an:\n" +
 			"             - example"
 
-		value := formatValue(string(input), 1)
+		value := formatValue(input, 1)
 
 		assert.Equal(tt, expected, value)
 	})
 
-}
-
-func String(v string) *string {
-	return &v
 }

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -1,0 +1,27 @@
+package printer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrint(t *testing.T) {
+	t.Run("parses simple plans", func(tt *testing.T) {
+		input := "this:\n  is:\n    an:\n      - example"
+
+		expected := "this:\n" +
+			"         is:\n" +
+			"           an:\n" +
+			"             - example"
+
+		value := formatValue(string(input), 1)
+
+		assert.Equal(tt, expected, value)
+	})
+
+}
+
+func String(v string) *string {
+	return &v
+}


### PR DESCRIPTION
Removed string limit from formatValue which is removing the last line from templates that don't have a newline at the end. I didn't find any other printer tests so I'm not sure if this breaks anything :man_shrugging: 