### PR TITLE
Added test case - parser fails on hyphens

### DIFF
--- a/fixtures/processedPlans/simpleWithHyphens.txt
+++ b/fixtures/processedPlans/simpleWithHyphens.txt
@@ -1,0 +1,2 @@
+~ aws_subnet.dvo-vpc-1c
+      id: <computed>

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -66,6 +66,27 @@ func TestParse(t *testing.T) {
 		assert.Equal(tt, expected, plan)
 	})
 
+	t.Run("parses resources with hyphens", func(tt *testing.T) {
+		input, err := ioutil.ReadFile("../../fixtures/processedPlans/simpleWithHyphens.txt")
+		assert.NoError(tt, err)
+
+		expected := &Plan{
+			Resources: []*Resource{
+				{
+					Header: &Header{
+						Change: String("~"),
+						Name:   String("aws_subnet.dvo-vpc-1c"),
+					},
+				},
+			},
+		}
+
+		plan, err := Parse(string(input))
+		assert.NoError(t, err)
+
+		assert.Equal(tt, expected, plan)
+	})
+
 	t.Run("parses all types of resource changes", func(tt *testing.T) {
 		input, err := ioutil.ReadFile("../../fixtures/processedPlans/resourceChangeTypes.txt")
 		assert.NoError(tt, err)


### PR DESCRIPTION
Found an issue where the parser fails on resources with multiple hyphens. Not sure how to fix it, but I figured a test case would be useful.