### PR TITLE
fix(parsing): enable lookahead of 3

### DIFF
--- a/fixtures/processedPlans/resourceMetadataNoNewLine.txt
+++ b/fixtures/processedPlans/resourceMetadataNoNewLine.txt
@@ -1,0 +1,4 @@
++ local_file.config
+      id:                <computed>
+      filename:          "config.yaml"
+Plan: 1 to add, 0 to change, 0 to destroy.

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -78,7 +78,7 @@ const noChanges = "NO_CHANGES_STRING"
 
 // ErrParseFailure is returned by parser.Parse when the input string is unable
 // to be parsed.
-var ErrParseFailure = errors.New("validator not registered")
+var ErrParseFailure = errors.New("parse failure error")
 
 // Parse takes in an Terraform plan output string and returns a parsed
 // representation in the form of a Plan struct.
@@ -93,7 +93,11 @@ func Parse(inputPlan string) (*Plan, error) {
 		recover()
 	}()
 
-	p, err := participle.Build(&Plan{}, participle.Lexer(&SceneryDefinition{}))
+	p, err := participle.Build(
+		&Plan{},
+		participle.Lexer(&SceneryDefinition{}),
+		participle.UseLookahead(3),
+	)
 	if err != nil {
 		return &Plan{}, err
 	}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -248,6 +248,42 @@ func TestParse(t *testing.T) {
 
 		assert.Equal(tt, expected, plan)
 	})
+
+	t.Run("parses plan with no newline between resources and metadata", func(tt *testing.T) {
+		input, err := ioutil.ReadFile("../../fixtures/processedPlans/resourceMetadataNoNewLine.txt")
+		assert.NoError(tt, err)
+
+		expected := &Plan{
+			Resources: []*Resource{
+				{
+					Header: &Header{
+						Change: String("+"),
+						Name:   String("local_file.config"),
+					},
+					Attributes: []*Attribute{
+						{
+							Key:      String("id"),
+							Computed: String("<computed>"),
+						},
+						{
+							Key:   String("filename"),
+							Value: String("config.yaml"),
+						},
+					},
+				},
+			},
+			Metadata: &Metadata{
+				Add:     1,
+				Change:  0,
+				Destroy: 0,
+			},
+		}
+
+		plan, err := Parse(string(input))
+		assert.NoError(t, err)
+
+		assert.Equal(tt, expected, plan)
+	})
 }
 
 func String(v string) *string {


### PR DESCRIPTION
## What
- Enable parsing lookahead of 3 tokens instead of the default 1.

## Why
Without any lookahead there can be confusion between recognizing the beginning of the metadata and another attribute of the current resource block when there isn't a newline between the final resource and metadata blocks. For example:
```
+ local_file.config
      id:                <computed>
      filename:          "config.yaml"
Plan: 1 to add, 0 to change, 0 to destroy.
```

This is because `Plan:` is recognized as the `Key` of an `Attribute` when only using a lookahead count of 1 (the default). Increasing the lookahead count eliminates the confusion and participle is able to determine that the `Resource` is over and `Plan:` represents the beginning of the `Metadata` block.

Closes #22 