### PR TITLE
feat(base64): decode base64 simple output if possible

### DIFF
--- a/fixtures/rawPlans/base64CreateInput.txt
+++ b/fixtures/rawPlans/base64CreateInput.txt
@@ -1,0 +1,3 @@
++ aws_instance.master
+    id:               <computed>
+    user_data_base64: "IyEvYmluL2Jhc2gKCmZvciAoKCBjb3VudGVyPTEwOyBjb3VudGVyPjA7IGNvdW50ZXItLSApKQpkbwogIGVjaG8gLW4gIiRjb3VudGVyICIKZG9uZQogIHByaW50ZiAiXG4iCg=="

--- a/fixtures/rawPlans/base64CreateOutput.txt
+++ b/fixtures/rawPlans/base64CreateOutput.txt
@@ -1,0 +1,11 @@
++ aws_instance.master
+    id:               <computed>
+    user_data_base64: "#!/bin/bash
+                       
+                       for (( counter=10; counter>0; counter-- ))
+                       do
+                         echo -n "$counter "
+                       done
+                         printf "\n"
+                       "
+

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -264,6 +264,9 @@ func formatValue(value string, indentLength int) string {
 		formattedValue := strings.Replace(value, "\n", newlineReplacement, -1)
 
 		return formattedValue
+	} else if decodedString, err := base64.StdEncoding.DecodeString(value); err == nil && isASCII(decodedString) {
+
+		return formatValue(string(decodedString), indentLength)
 	}
 
 	return value

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -20,6 +20,7 @@ func TestPrintPlan(t *testing.T) {
 		outputFile string
 	}{
 		{"../../fixtures/rawPlans/base64Input.txt", "../../fixtures/rawPlans/base64Output.txt"},
+		{"../../fixtures/rawPlans/base64CreateInput.txt", "../../fixtures/rawPlans/base64CreateOutput.txt"},
 		{"../../fixtures/rawPlans/multilineAttributeInput.txt", "../../fixtures/rawPlans/multilineAttributeOutput.txt"},
 	}
 


### PR DESCRIPTION
Some attributes in the Terraform output are sometimes base64 encoded. These values sometimes contain human readable information that would be useful to have decoded. #16 added the ability to diff the decoded base64 data to more easily understand the changed values. We forgot to add this ability on simple terraform attributes (that is, non-changes). This PR adds this functionality.

**Example**
```
# Before
+ aws_instance.master
    id:               <computed>
    user_data_base64: "IyEvYmluL2Jhc2gKCmZvciAoKCBjb3VudGVyPTEwOyBjb3VudGVyPjA7IGNvdW50ZXItLSApKQpkbwogIGVjaG8gLW4gIiRjb3VudGVyICIKZG9uZQogIHByaW50ZiAiXG4iCg=="


# After 
+ aws_instance.master
    id:               <computed>
    user_data_base64: "#!/bin/bash

                        for (( counter=10; counter>0; counter-- ))
                       do
                         echo -n "$counter "
                       done
                         printf "\n"
                       "
```