### PR TITLE
fix(number): fix printing float precision

### DIFF
--- a/fixtures/rawPlans/floatInput.txt
+++ b/fixtures/rawPlans/floatInput.txt
@@ -1,0 +1,3 @@
++ foo.bar
+    version: "1.10"
+    versionDiff: "{ \"number\": 1.10 }" => "{ \"number\": 2.0 }"

--- a/fixtures/rawPlans/floatOutput.txt
+++ b/fixtures/rawPlans/floatOutput.txt
@@ -1,0 +1,8 @@
++ foo.bar
+    version:     "1.10"
+    versionDiff:  {
+                 -  "number": 1.10
+                 +  "number": 2.0
+                  }
+                 
+

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -135,8 +135,13 @@ func processComplexAttributes(a *parser.Attribute, indentLength int) {
 
 		var old, new interface{}
 
-		json.Unmarshal(bBefore, &old) // nolint:gosec
-		json.Unmarshal(bAfter, &new)  // nolint:gosec
+		beforeDecoder := json.NewDecoder(strings.NewReader(*a.Before))
+		beforeDecoder.UseNumber()
+		beforeDecoder.Decode(&old) // nolint:gosec
+
+		afterDecoder := json.NewDecoder(strings.NewReader(*a.After))
+		afterDecoder.UseNumber()
+		afterDecoder.Decode(&new) // nolint:gosec
 
 		oldPretty, _ := json.MarshalIndent(old, "", "  ") // nolint:gosec
 		newPretty, _ := json.MarshalIndent(new, "", "  ") // nolint:gosec
@@ -245,7 +250,9 @@ func formatValue(value string, indentLength int) string {
 		// Is JSON?
 		var j interface{}
 
-		json.Unmarshal([]byte(value), &j) // nolint:gosec
+		decoder := json.NewDecoder(strings.NewReader(value))
+		decoder.UseNumber()
+		decoder.Decode(&j) // nolint:gosec
 
 		// 4 (attribute padding) + 1 (key/value space separation) + 1 (opening quote for value ")
 		jsonIdentLegth := indentLength + 4 + 1 + 1

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -22,6 +22,7 @@ func TestPrintPlan(t *testing.T) {
 		{"../../fixtures/rawPlans/base64Input.txt", "../../fixtures/rawPlans/base64Output.txt"},
 		{"../../fixtures/rawPlans/base64CreateInput.txt", "../../fixtures/rawPlans/base64CreateOutput.txt"},
 		{"../../fixtures/rawPlans/multilineAttributeInput.txt", "../../fixtures/rawPlans/multilineAttributeOutput.txt"},
+		{"../../fixtures/rawPlans/floatInput.txt", "../../fixtures/rawPlans/floatOutput.txt"},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
As reported in #28, floats are currently losing their precision because of how `json.Unmarshal` treats JSON numbers that end up being parsed as a float64. In order to avoid losing that precision and number representation we can use a JSON Decoder that unmarshals numbers as a `json.Number` instead of a float64.

Closes #28