### PR TITLE
fix(parser): keys that have "*" now work

### DIFF
--- a/fixtures/processedPlans/weirdKeys.txt
+++ b/fixtures/processedPlans/weirdKeys.txt
@@ -1,0 +1,4 @@
+
+  ~ module.module_name
+      silenced.%: "1" => "0"
+      silenced.*: "1556205536" => ""

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -64,7 +64,7 @@ type Header struct {
 //   `policy_arn:      "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"``
 //   `allow_overwrite: "" => "true"`
 type Attribute struct {
-	Key           *string `parser:"@(Ident { \".\" | \"#\" | \"%\" | \"~\" | \"/\" | \"-\" | Ident | Float }) \":\""`
+	Key           *string `parser:"@(Ident { \".\" | \"#\" | \"%\" | \"*\" | \"~\" | \"/\" | \"-\" | Ident | Float }) \":\""`
 	Before        *string `parser:"((@String \"=\" \">\""`
 	After         *string `parser:"  (@String"`
 	AfterComputed *string `parser:" 	| @(\"<\" Ident \">\")))"`

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -156,6 +156,42 @@ func TestParse(t *testing.T) {
 		assert.Equal(tt, expected, plan)
 	})
 
+	t.Run("parses weird keys plan", func(tt *testing.T) {
+		input, err := ioutil.ReadFile("../../fixtures/processedPlans/weirdKeys.txt")
+		assert.NoError(tt, err)
+
+		expected := &Plan{
+			Resources: []*Resource{
+				{
+					Header: &Header{
+						Change:      String("~"),
+						Name:        String("module.module_name"),
+						NewResource: false,
+					},
+					Attributes: []*Attribute{
+						{
+							Key:         String("silenced.%"),
+							Before:      String("1"),
+							After:       String("0"),
+							NewResource: false,
+						},
+						{
+							Key:         String("silenced.*"),
+							Before:      String("1556205536"),
+							After:       String(""),
+							NewResource: false,
+						},
+					},
+				},
+			}}
+
+		plan, err := Parse(string(input))
+		assert.NoError(t, err)
+
+		assert.Equal(tt, expected, plan)
+	})
+
+
 	t.Run("parses complex plan", func(tt *testing.T) {
 		input, err := ioutil.ReadFile("../../fixtures/processedPlans/complex.txt")
 		assert.NoError(tt, err)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -191,7 +191,6 @@ func TestParse(t *testing.T) {
 		assert.Equal(tt, expected, plan)
 	})
 
-
 	t.Run("parses complex plan", func(tt *testing.T) {
 		input, err := ioutil.ReadFile("../../fixtures/processedPlans/complex.txt")
 		assert.NoError(tt, err)


### PR DESCRIPTION
Previously any key such as:

```
      silenced.*: "1556205536" => ""
```

Would not be parsed, this PR fixes this issue.