### PR TITLE
Exit with an error code if failed to parse

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -75,6 +75,7 @@ func runScenery(cmd *cobra.Command, args []string) {
 			if err == parser.ErrParseFailure {
 				os.Stderr.WriteString(color.RedString("Failed to parse plan. Returning original input.\n")) // nolint: gosec
 				fmt.Println(input)
+				os.Exit(1)
 				return
 			}
 		}
@@ -84,6 +85,7 @@ func runScenery(cmd *cobra.Command, args []string) {
 		if plan == nil {
 			os.Stderr.WriteString(color.RedString("Failed to parse plan. Returning original input.\n")) // nolint: gosec
 			fmt.Println(input)
+			os.Exit(1)
 			return
 		}
 


### PR DESCRIPTION
I am using Scenery with Atlantis and if scenery fails to parse the output of a plan or apply it still returns an exit code of 0. This results in the Github checks passing instead of failing as one would expect them to if something went wrong.