### PR TITLE
fix(cmd): use value from --no-color to allow forced usage

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -42,8 +42,8 @@ func runScenery(cmd *cobra.Command, args []string) {
 	var input string
 	var foundInput bool
 
-	if noColor {
-		color.NoColor = true
+	if noColor || cmd.Flags().Changed("no-color") {
+		color.NoColor = noColor
 	}
 
 	stat, _ := os.Stdin.Stat() // nolint: gosec


### PR DESCRIPTION
Greetings 👋 

While trying to integrate scenery with some CI process, I noticed that I didn't get colored output (not a TTY) caused by https://github.com/fatih/color/blob/master/color.go#L20. This changes enable the use of the `--no-color` flag to set up the `color.NoColor` property.

By default it will still rely on detecting a TTY but if you explicitly set `--no-color=false` it will enable colors.

Let me know what you think,

Adrien